### PR TITLE
Modernize the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/derekdreery/mtree-rs"
 edition = "2018"
 
 [dependencies]
-smallvec = "0.6"
+smallvec = "1.13"
 newtype_array = "0.1"
-bitflags = "1"
+bitflags = "2"
 
 [badges]
 travis-ci = { repository = "derekdreery/mtree-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate for iterating through the entries of an mtree record file
 categories = ["parsing", "os::unix-apis", "filesystem"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/derekdreery/mtree-rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 smallvec = "1.13"

--- a/examples/read_mtree.rs
+++ b/examples/read_mtree.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::error::Error;
 use std::fs::File;
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let path = env::current_dir()?.join("examples/gedit.mtree");
     let mtree = MTree::from_reader(File::open(path)?);
     for entry in mtree {

--- a/examples/read_mtree.rs
+++ b/examples/read_mtree.rs
@@ -4,7 +4,11 @@ use std::error::Error;
 use std::fs::File;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let path = env::current_dir()?.join("examples/gedit.mtree");
+    let args: Vec<_> = env::args().collect();
+    let path = match args.get(1) {
+        Some(p) => p.into(),
+        None => env::current_dir()?.join("examples/gedit.mtree"),
+    };
     let mtree = MTree::from_reader(File::open(path)?);
     for entry in mtree {
         println!("{}", entry?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ where
     pub fn from_reader(reader: R) -> MTree<R> {
         MTree {
             inner: BufReader::new(reader).split(b'\n'),
-            cwd: env::current_dir().unwrap_or(PathBuf::new()),
+            cwd: env::current_dir().unwrap_or_default(),
             default_params: Params::default(),
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -431,6 +431,7 @@ fn test_type_from_bytes() {
 
 bitflags::bitflags! {
     /// Unix file permissions.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct Perms: u8 {
         /// Entity has read access.
         const READ = 0b100;
@@ -500,9 +501,9 @@ impl FileMode {
             Some(FileMode {
                 setuid,
                 setgid,
-                owner: Perms { bits: owner },
-                group: Perms { bits: group },
-                other: Perms { bits: other },
+                owner: Perms::from_bits(owner)?,
+                group: Perms::from_bits(group)?,
+                other: Perms::from_bits(other)?,
             })
         }
         from_bytes_opt(input).ok_or_else(|| {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -317,7 +317,7 @@ impl Format {
             b"svr3" => Format::Svr3,
             b"svr4" => Format::Svr4,
             b"ultrix" => Format::Ultrix,
-            ref other => {
+            other => {
                 return Err(format!(
                     r#""{}" is not a valid format"#,
                     String::from_utf8_lossy(other)
@@ -348,7 +348,7 @@ fn test_format_from_butes() {
         (&b"svr4"[..], Format::Svr4),
         (&b"ultrix"[..], Format::Ultrix),
     ] {
-        assert_eq!(Format::from_bytes(&input[..]), Ok(res));
+        assert_eq!(Format::from_bytes(input), Ok(res));
     }
 }
 
@@ -415,16 +415,14 @@ impl fmt::Display for FileType {
 
 #[test]
 fn test_type_from_bytes() {
-    for (input, res) in vec![
-        (&b"block"[..], FileType::BlockDevice),
+    for (input, res) in [(&b"block"[..], FileType::BlockDevice),
         (&b"char"[..], FileType::CharacterDevice),
         (&b"dir"[..], FileType::Directory),
         (&b"fifo"[..], FileType::Fifo),
         (&b"file"[..], FileType::File),
         (&b"link"[..], FileType::SymbolicLink),
-        (&b"socket"[..], FileType::Socket),
-    ] {
-        assert_eq!(FileType::from_bytes(&input[..]), Ok(res));
+        (&b"socket"[..], FileType::Socket)] {
+        assert_eq!(FileType::from_bytes(input), Ok(res));
     }
     assert!(FileType::from_bytes(&b"other"[..]).is_err());
 }


### PR DESCRIPTION
Hi,

I'm interested in parsing the mtree format. This is a minimal first step at updating the dependencies and updating to a new rust edition.

I have verified that the crate still works (can parse files from modern arch linux packages, which is where my interest lies and based on the example file, yours too).

I don't know if it will be suitable for my uses yet (I haven't benchmarked the parser and I find the hex parsing code a bit convoluted, is it really needed on modern rust?). There are probably some other things that could be cleaned up with more modern rust that I might do if I actually end up using this for my project (if my project even ends up happening, it is a hobby project after all).

There are also a couple of clippy warnings from newtype_array that I haven't looked into:

```
warning: re-implementing `PartialEq::ne` is unnecessary
   --> src/util.rs:214:1
    |
214 | newtype_array!(pub struct Array48(48));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_ne_impl
    = note: `#[warn(clippy::partialeq_ne_impl)]` on by default
    = note: this warning originates in the macro `__impl_slice_eq1` which comes from the expansion of the macro `newtype_array` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: re-implementing `PartialEq::ne` is unnecessary
   --> src/util.rs:215:1
    |
215 | newtype_array!(pub struct Array64(64));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_ne_impl
    = note: this warning originates in the macro `__impl_slice_eq1` which comes from the expansion of the macro `newtype_array` (in Nightly builds, run with -Z macro-backtrace for more info)
```

You might want to make a new release with this given the updated dependencies with new semvers.