### PR TITLE
Proposed API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ repository = "https://github.com/derekdreery/mtree-rs"
 edition = "2021"
 
 [dependencies]
-smallvec = "1.13"
 bitflags = "2"
 faster-hex = { version = "0.9.0", default-features = false }
+memchr = "2.7.4"
+smallvec = "1.13"
 
 [badges]
 travis-ci = { repository = "derekdreery/mtree-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/derekdreery/mtree-rs"
 edition = "2018"
 
 [dependencies]
-smallvec = "0.6"
+smallvec = "1.13"
 newtype_array = "0.1"
-bitflags = "1"
+bitflags = "2"
 
 [badges]
 travis-ci = { repository = "derekdreery/mtree-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 smallvec = "1.13"
 bitflags = "2"
+faster-hex = { version = "0.9.0", default-features = false }
 
 [badges]
 travis-ci = { repository = "derekdreery/mtree-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A crate for iterating through the entries of an mtree record file
 categories = ["parsing", "os::unix-apis", "filesystem"]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/derekdreery/mtree-rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 smallvec = "1.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 
 [dependencies]
 smallvec = "1.13"
-newtype_array = "0.1"
 bitflags = "2"
 
 [badges]

--- a/examples/read_mtree.rs
+++ b/examples/read_mtree.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::error::Error;
 use std::fs::File;
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let path = env::current_dir()?.join("examples/gedit.mtree");
     let mtree = MTree::from_reader(File::open(path)?);
     for entry in mtree {

--- a/examples/read_mtree.rs
+++ b/examples/read_mtree.rs
@@ -4,7 +4,11 @@ use std::error::Error;
 use std::fs::File;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let path = env::current_dir()?.join("examples/gedit.mtree");
+    let args: Vec<_> = env::args().collect();
+    let path = match args.get(1) {
+        Some(p) => p.into(),
+        None => env::current_dir()?.join("examples/gedit.mtree"),
+    };
     let mtree = MTree::from_reader(File::open(path)?);
     for entry in mtree {
         println!("{}", entry?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ impl Entry {
     }
 
     /// `gid` The file group as a numeric value.
-    pub fn gid(&self) -> Option<u64> {
+    pub fn gid(&self) -> Option<u32> {
         self.params.gid
     }
 
@@ -297,7 +297,7 @@ impl Entry {
     }
 
     /// The file owner as a numeric value.
-    pub fn uid(&self) -> Option<u64> {
+    pub fn uid(&self) -> Option<u32> {
         self.params.uid
     }
 
@@ -325,7 +325,7 @@ struct Params {
     /// `flags` The file flags as a symbolic name.
     pub flags: Option<Vec<u8>>,
     /// `gid` The file group as a numeric value.
-    pub gid: Option<u64>,
+    pub gid: Option<u32>,
     /// `gname` The file group as a symbolic name.
     ///
     /// The name can be up to 32 chars and must match regex `[a-z_][a-z0-9_-]*[$]?`.
@@ -370,7 +370,7 @@ struct Params {
     /// `type` The type of the file.
     pub file_type: Option<FileType>,
     /// The file owner as a numeric value.
-    pub uid: Option<u64>,
+    pub uid: Option<u32>,
     /// The file owner as a symbolic name.
     ///
     /// The name can be up to 32 chars and must match regex `[a-z_][a-z0-9_-]*[$]?`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,6 @@
 //!
 //! [mtree(5)]: https://www.freebsd.org/cgi/man.cgi?mtree(5)
 
-#[macro_use]
-extern crate newtype_array;
-
 use smallvec::SmallVec;
 use std::env;
 use std::ffi::OsStr;
@@ -57,7 +54,7 @@ mod util;
 
 pub use parser::{FileMode, FileType, Format, ParserError, Perms};
 use parser::{Keyword, MTreeLine, SpecialKind};
-use util::{decode_escapes_path, Array48, Array64};
+use util::decode_escapes_path;
 
 #[cfg(not(unix))]
 compiler_error!("This library currently only supports unix, due to windows using utf-16 for paths");
@@ -278,12 +275,12 @@ impl Entry {
 
     /// `sha384|sha384digest` The FIPS 180-2 ("SHA-384") message digest of the file.
     pub fn sha384(&self) -> Option<&[u8; 48]> {
-        self.params.sha384.as_ref().map(|v| v.as_ref())
+        self.params.sha384.as_ref()
     }
 
     /// `sha512|sha512digest` The FIPS 180-2 ("SHA-512") message digest of the file.
     pub fn sha512(&self) -> Option<&[u8; 64]> {
-        self.params.sha512.as_ref().map(|v| v.as_ref())
+        self.params.sha512.as_ref()
     }
 
     /// `size` The size, in bytes, of the file.
@@ -365,9 +362,9 @@ struct Params {
     /// `sha256|sha256digest` The FIPS 180-2 ("SHA-256") message digest of the file.
     pub sha256: Option<[u8; 32]>,
     /// `sha384|sha384digest` The FIPS 180-2 ("SHA-384") message digest of the file.
-    pub sha384: Option<Array48<u8>>,
+    pub sha384: Option<[u8; 48]>,
     /// `sha512|sha512digest` The FIPS 180-2 ("SHA-512") message digest of the file.
-    pub sha512: Option<Array64<u8>>,
+    pub sha512: Option<[u8; 64]>,
     /// `size` The size, in bytes, of the file.
     pub size: Option<u64>,
     /// `time` The last modification time of the file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ where
     pub fn from_reader(reader: R) -> MTree<R> {
         MTree {
             inner: BufReader::new(reader).split(b'\n'),
-            cwd: env::current_dir().unwrap_or(PathBuf::new()),
+            cwd: env::current_dir().unwrap_or_default(),
             default_params: Params::default(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,9 @@ where
                     panic!("relative without a current working dir");
                 }
                 Some(Entry {
-                    path: util::decode_escapes_path(self.cwd.join(OsStr::from_bytes(path)))
-                        .ok_or(Error::Parser(ParserError("Failed to decode escapes".into())))?,
+                    path: util::decode_escapes_path(self.cwd.join(OsStr::from_bytes(path))).ok_or(
+                        Error::Parser(ParserError("Failed to decode escapes".into())),
+                    )?,
                     params,
                 })
             }
@@ -124,9 +125,10 @@ where
                 let mut params = self.default_params.clone();
                 params.set_list(keywords.into_iter());
                 Some(Entry {
-                    path: util::decode_escapes_path(
-                        Path::new(OsStr::from_bytes(path)).to_owned(),
-                    ).ok_or(Error::Parser(ParserError("Failed to decode escapes".into())))?,
+                    path: util::decode_escapes_path(Path::new(OsStr::from_bytes(path)).to_owned())
+                        .ok_or(Error::Parser(ParserError(
+                            "Failed to decode escapes".into(),
+                        )))?,
                     params,
                 })
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,9 +108,10 @@ where
                     panic!("relative without a current working dir");
                 }
                 Some(Entry {
-                    path: util::decode_escapes_path(self.cwd.join(OsStr::from_bytes(path))).ok_or(
-                        Error::Parser(ParserError("Failed to decode escapes".into())),
-                    )?,
+                    path: util::decode_escapes_path(self.cwd.join(OsStr::from_bytes(path)))
+                        .ok_or_else(|| {
+                            Error::Parser(ParserError("Failed to decode escapes".into()))
+                        })?,
                     params,
                 })
             }
@@ -123,9 +124,9 @@ where
                 params.set_list(keywords.into_iter());
                 Some(Entry {
                     path: util::decode_escapes_path(Path::new(OsStr::from_bytes(path)).to_owned())
-                        .ok_or(Error::Parser(ParserError(
-                            "Failed to decode escapes".into(),
-                        )))?,
+                        .ok_or_else(|| {
+                            Error::Parser(ParserError("Failed to decode escapes".into()))
+                        })?,
                     params,
                 })
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ impl Entry {
 
     /// `sha1|sha1digest` The FIPS 160-1 ("SHA-1") message digest of the file.
     pub fn sha1(&self) -> Option<&[u8; 20]> {
-        self.params.sha1.as_ref()
+        self.params.sha1.as_ref().map(|v| v.as_ref())
     }
 
     /// `sha256|sha256digest` The FIPS 180-2 ("SHA-256") message digest of the file.
@@ -275,12 +275,12 @@ impl Entry {
 
     /// `sha384|sha384digest` The FIPS 180-2 ("SHA-384") message digest of the file.
     pub fn sha384(&self) -> Option<&[u8; 48]> {
-        self.params.sha384.as_ref()
+        self.params.sha384.as_ref().map(|v| v.as_ref())
     }
 
     /// `sha512|sha512digest` The FIPS 180-2 ("SHA-512") message digest of the file.
     pub fn sha512(&self) -> Option<&[u8; 64]> {
-        self.params.sha512.as_ref()
+        self.params.sha512.as_ref().map(|v| v.as_ref())
     }
 
     /// `size` The size, in bytes, of the file.
@@ -331,7 +331,7 @@ struct Params {
     /// `gname` The file group as a symbolic name.
     ///
     /// The name can be up to 32 chars and must match regex `[a-z_][a-z0-9_-]*[$]?`.
-    pub gname: Option<SmallVec<[u8; 32]>>,
+    pub gname: Option<SmallVec<[u8; 8]>>,
     /// `ignore` Ignore any file hierarchy below this line.
     pub ignore: bool,
     /// `inode` The inode number.
@@ -358,13 +358,13 @@ struct Params {
     /// the file.
     pub rmd160: Option<[u8; 20]>,
     /// `sha1|sha1digest` The FIPS 160-1 ("SHA-1") message digest of the file.
-    pub sha1: Option<[u8; 20]>,
+    pub sha1: Option<Box<[u8; 20]>>,
     /// `sha256|sha256digest` The FIPS 180-2 ("SHA-256") message digest of the file.
     pub sha256: Option<[u8; 32]>,
     /// `sha384|sha384digest` The FIPS 180-2 ("SHA-384") message digest of the file.
-    pub sha384: Option<[u8; 48]>,
+    pub sha384: Option<Box<[u8; 48]>>,
     /// `sha512|sha512digest` The FIPS 180-2 ("SHA-512") message digest of the file.
-    pub sha512: Option<[u8; 64]>,
+    pub sha512: Option<Box<[u8; 64]>>,
     /// `size` The size, in bytes, of the file.
     pub size: Option<u64>,
     /// `time` The last modification time of the file.
@@ -376,7 +376,7 @@ struct Params {
     /// The file owner as a symbolic name.
     ///
     /// The name can be up to 32 chars and must match regex `[a-z_][a-z0-9_-]*[$]?`.
-    pub uname: Option<SmallVec<[u8; 32]>>,
+    pub uname: Option<SmallVec<[u8; 8]>>,
 }
 
 impl Params {
@@ -416,10 +416,10 @@ impl Params {
             Keyword::Optional => self.optional = false,
             Keyword::ResidentDeviceRef(device) => self.resident_device = Some(device.to_device()),
             Keyword::Rmd160(rmd160) => self.rmd160 = Some(rmd160),
-            Keyword::Sha1(sha1) => self.sha1 = Some(sha1),
+            Keyword::Sha1(sha1) => self.sha1 = Some(Box::new(sha1)),
             Keyword::Sha256(sha256) => self.sha256 = Some(sha256),
-            Keyword::Sha384(sha384) => self.sha384 = Some(sha384),
-            Keyword::Sha512(sha512) => self.sha512 = Some(sha512),
+            Keyword::Sha384(sha384) => self.sha384 = Some(Box::new(sha384)),
+            Keyword::Sha512(sha512) => self.sha512 = Some(Box::new(sha512)),
             Keyword::Size(size) => self.size = Some(size),
             Keyword::Time(time) => self.time = Some(UNIX_EPOCH + time),
             Keyword::Type(ty) => self.file_type = Some(ty),
@@ -524,7 +524,7 @@ impl fmt::Display for Params {
         }
         if let Some(ref v) = self.sha1 {
             write!(f, "sha1: ")?;
-            for ch in v {
+            for ch in v.iter() {
                 write!(f, "{:x}", ch)?;
             }
             writeln!(f)?;
@@ -538,14 +538,14 @@ impl fmt::Display for Params {
         }
         if let Some(ref v) = self.sha384 {
             write!(f, "sha384: ")?;
-            for ch in v {
+            for ch in v.iter() {
                 write!(f, "{:x}", ch)?;
             }
             writeln!(f)?;
         }
         if let Some(ref v) = self.sha512 {
             write!(f, "sha512: ")?;
-            for ch in v {
+            for ch in v.iter() {
                 write!(f, "{:x}", ch)?;
             }
             writeln!(f)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -481,9 +481,8 @@ impl FileMode {
         }
         Ok(FileMode {
             mode: u32::from_str_radix(
-                std::str::from_utf8(input).map_err(|err| {
-                    ParserError(format!("failed to parse mode value: {err}"))
-                })?,
+                std::str::from_utf8(input)
+                    .map_err(|err| ParserError(format!("failed to parse mode value: {err}")))?,
                 8,
             )
             .map_err(|err| ParserError(format!("failed to parse mode as integer: {err}")))?,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -111,7 +111,7 @@ pub enum Keyword<'a> {
     /// I think this is bsd-specific.
     Flags(&'a [u8]),
     /// `gid` The file group as a numeric value.
-    Gid(u64),
+    Gid(u32),
     /// `gname` The file group as a symbolic name.
     Gname(&'a [u8]),
     /// `ignore` Ignore any file hierarchy below this line.
@@ -156,7 +156,7 @@ pub enum Keyword<'a> {
     /// `type` The type of the file.
     Type(FileType),
     /// The file owner as a numeric value.
-    Uid(u64),
+    Uid(u32),
     /// The file owner as a symbolic name.
     Uname(&'a [u8]),
 }
@@ -173,7 +173,7 @@ impl<'a> Keyword<'a> {
             b"device" => Keyword::DeviceRef(DeviceRef::from_bytes(next("devices", iter.next())?)?),
             b"contents" => Keyword::Contents(next("contents", iter.next())?),
             b"flags" => Keyword::Flags(next("flags", iter.next())?),
-            b"gid" => Keyword::Gid(u64::from_dec(next("gid", iter.next())?)?),
+            b"gid" => Keyword::Gid(u32::from_dec(next("gid", iter.next())?)?),
             b"gname" => Keyword::Gname(next("gname", iter.next())?),
             b"ignore" => Keyword::Ignore,
             b"inode" => Keyword::Inode(u64::from_dec(next("inode", iter.next())?)?),
@@ -209,7 +209,7 @@ impl<'a> Keyword<'a> {
             b"size" => Keyword::Size(u64::from_dec(next("size", iter.next())?)?),
             b"time" => Keyword::Time(parse_time(next("time", iter.next())?)?),
             b"type" => Keyword::Type(FileType::from_bytes(next("type", iter.next())?)?),
-            b"uid" => Keyword::Uid(u64::from_dec(next("uid", iter.next())?)?),
+            b"uid" => Keyword::Uid(u32::from_dec(next("uid", iter.next())?)?),
             b"uname" => Keyword::Uname(next("uname", iter.next())?),
             other => {
                 return Err(format!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 //! Stuff for parsing mtree files.
 use crate::{
-    util::{parse_time, Array48, Array64, FromDec, FromHex},
+    util::{parse_time, FromDec, FromHex},
     Device,
 };
 use std::{fmt, time::Duration};
@@ -144,9 +144,9 @@ pub enum Keyword<'a> {
     /// `sha256|sha256digest` The FIPS 180-2 ("SHA-256") message digest of the file.
     Sha256([u8; 32]),
     /// `sha384|sha384digest` The FIPS 180-2 ("SHA-384") message digest of the file.
-    Sha384(Array48<u8>),
+    Sha384([u8; 48]),
     /// `sha512|sha512digest` The FIPS 180-2 ("SHA-512") message digest of the file.
-    Sha512(Array64<u8>),
+    Sha512([u8; 64]),
     /// `size` The size, in bytes, of the file.
     Size(u64),
     /// `time` The last modification time of the file, as a duration since the unix epoch.
@@ -198,11 +198,11 @@ impl<'a> Keyword<'a> {
                 "sha256|sha256digest",
                 iter.next(),
             )?)?),
-            b"sha384" | b"sha384digest" => Keyword::Sha384(<Array48<u8>>::from_hex(next(
+            b"sha384" | b"sha384digest" => Keyword::Sha384(<[u8; 48]>::from_hex(next(
                 "sha384|sha384digest",
                 iter.next(),
             )?)?),
-            b"sha512" | b"sha512digest" => Keyword::Sha512(<Array64<u8>>::from_hex(next(
+            b"sha512" | b"sha512digest" => Keyword::Sha512(<[u8; 64]>::from_hex(next(
                 "sha512|sha512digest",
                 iter.next(),
             )?)?),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -482,11 +482,11 @@ impl FileMode {
         Ok(FileMode {
             mode: u32::from_str_radix(
                 std::str::from_utf8(input).map_err(|err| {
-                    ParserError(format!("failed to parse mode value: {err}").into())
+                    ParserError(format!("failed to parse mode value: {err}"))
                 })?,
                 8,
             )
-            .map_err(|err| ParserError(format!("failed to parse mode as integer: {err}").into()))?,
+            .map_err(|err| ParserError(format!("failed to parse mode as integer: {err}")))?,
         })
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -431,6 +431,7 @@ fn test_type_from_bytes() {
 
 bitflags::bitflags! {
     /// Unix file permissions.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct Perms: u8 {
         /// Entity has read access.
         const READ = 0b100;
@@ -500,9 +501,9 @@ impl FileMode {
             Some(FileMode {
                 setuid,
                 setgid,
-                owner: Perms { bits: owner },
-                group: Perms { bits: group },
-                other: Perms { bits: other },
+                owner: Perms::from_bits(owner)?,
+                group: Perms::from_bits(group)?,
+                other: Perms::from_bits(other)?,
             })
         }
         from_bytes_opt(input).ok_or_else(|| {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -317,7 +317,7 @@ impl Format {
             b"svr3" => Format::Svr3,
             b"svr4" => Format::Svr4,
             b"ultrix" => Format::Ultrix,
-            ref other => {
+            other => {
                 return Err(format!(
                     r#""{}" is not a valid format"#,
                     String::from_utf8_lossy(other)
@@ -348,7 +348,7 @@ fn test_format_from_butes() {
         (&b"svr4"[..], Format::Svr4),
         (&b"ultrix"[..], Format::Ultrix),
     ] {
-        assert_eq!(Format::from_bytes(&input[..]), Ok(res));
+        assert_eq!(Format::from_bytes(input), Ok(res));
     }
 }
 
@@ -415,16 +415,14 @@ impl fmt::Display for FileType {
 
 #[test]
 fn test_type_from_bytes() {
-    for (input, res) in vec![
-        (&b"block"[..], FileType::BlockDevice),
+    for (input, res) in [(&b"block"[..], FileType::BlockDevice),
         (&b"char"[..], FileType::CharacterDevice),
         (&b"dir"[..], FileType::Directory),
         (&b"fifo"[..], FileType::Fifo),
         (&b"file"[..], FileType::File),
         (&b"link"[..], FileType::SymbolicLink),
-        (&b"socket"[..], FileType::Socket),
-    ] {
-        assert_eq!(FileType::from_bytes(&input[..]), Ok(res));
+        (&b"socket"[..], FileType::Socket)] {
+        assert_eq!(FileType::from_bytes(input), Ok(res));
     }
     assert!(FileType::from_bytes(&b"other"[..]).is_err());
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -158,8 +158,10 @@ pub fn decode_escapes_path(path: std::path::PathBuf) -> Option<std::path::PathBu
 
 /// Spaces and other special characters are escaped, take care of that
 pub fn decode_escapes(buf: &mut [u8]) -> Option<&mut [u8]> {
-    let mut read_idx = 0;
-    let mut write_idx = 0;
+    // Skip forward to the first escape character using a fast search.
+    // Hopefully there will be nothing to do in the majority of cases
+    let mut read_idx = memchr::memchr(b'\\', buf).unwrap_or(buf.len());
+    let mut write_idx = read_idx;
     while read_idx < buf.len() {
         if buf[read_idx] == b'\\' {
             let ch = (from_oct_ch(buf[read_idx + 1])? << 6)

--- a/src/util.rs
+++ b/src/util.rs
@@ -92,48 +92,8 @@ macro_rules! impl_FromHex_arr {
 impl_FromHex_arr!(16);
 impl_FromHex_arr!(20);
 impl_FromHex_arr!(32);
-
-macro_rules! impl_FromHex_newtype {
-    ($type:ty, $size:expr) => {
-        impl FromHex for $type {
-            #[inline]
-            fn from_hex(input: &[u8]) -> ParserResult<Self> {
-                if input.len() != 2 * $size {
-                    return Err(format!(
-                        r#"input length ({}) must be twice the vec size ({}), but \
-                                                                        it is not (in "{}")"#,
-                        input.len(),
-                        $size,
-                        String::from_utf8_lossy(input)
-                    )
-                    .into());
-                }
-                let mut acc = [0; $size];
-                for (idx, chunk) in input.chunks(2).enumerate() {
-                    let high = from_hex_ch(chunk[0]).ok_or_else(|| {
-                        format!(
-                            r#"char at position {} in "{}" is not hex"#,
-                            2 * idx,
-                            String::from_utf8_lossy(input)
-                        )
-                    })?;
-                    let low = from_hex_ch(chunk[1]).ok_or_else(|| {
-                        format!(
-                            r#"char at position {} in "{}" is not hex"#,
-                            2 * idx + 1,
-                            String::from_utf8_lossy(input)
-                        )
-                    })?;
-                    acc[idx] = high * 16 + low;
-                }
-                Ok(acc.into())
-            }
-        }
-    };
-}
-
-impl_FromHex_newtype!(Array48<u8>, 48);
-impl_FromHex_newtype!(Array64<u8>, 64);
+impl_FromHex_arr!(48);
+impl_FromHex_arr!(64);
 
 impl FromHex for u128 {
     /// Convert hex to u128
@@ -210,9 +170,6 @@ pub fn parse_time(input: &[u8]) -> ParserResult<Duration> {
     let nano = u32::from_dec(nano)?;
     Ok(Duration::new(sec, nano))
 }
-
-newtype_array!(pub struct Array48(48));
-newtype_array!(pub struct Array64(64));
 
 /// Spaces and other special characters are escaped, take care of that
 pub fn decode_escapes_path(path: std::path::PathBuf) -> Option<std::path::PathBuf> {


### PR DESCRIPTION
This builds on top of my other PR: #2  so please ignore those commits here.

These are some API changes I need to make this suitable for my use case.

## Unix UID & GID are actually only 32-bit

This is also exposed in Rust standard library types:
https://doc.rust-lang.org/std/os/unix/fs/trait.MetadataExt.html#tymethod.uid
https://doc.rust-lang.org/std/os/unix/fs/trait.MetadataExt.html#tymethod.gid

So there is no point in supporting more than that.

This can lead to slightly smaller structures, but more importantly less conversion back and forth.

## Breaking change: Keep FileMode as numeric, implement support for sticky bit

* The FileMode structure was larger than it needed to be (since it was stored split apart for the suid/sgid bit)
* Sticky bit wasn't supported
* Incorrect parsing for leptonica license file (it had mode=66 which is valid, but probably not intended). So modes can be at most 4 octal characters. But it can be fewer than 3.

I need to get back the original numeric mode, so for my purposes it is just better to store the file mode in that format. I have added accessor functions corresponding to the old fields.

## Resolve escapes in file paths

Turns out that mtree uses octal escapes for spaces and other special characters in it's format. E.g. `./opt/resolve/LUT/Blackmagic\040Design/Blackmagic\0404.6K\040Film\040to\040Rec709.cube time=1702074712.0 size=1401680 md5digest=716a06abc75feda9c70ce72c32b94d2b sha256digest=10a3f470dde8d7359c56793c268a0c0f3973711f5db9e37ee7efbc0b13ee7263`

I believe mtree should convert those (as opposed to leaving that to the consuming application). I have implemented such support for file name and symlink target names. My implementation seems fast enough, I don't know if it is as fast as can be though. It does incur one additional allocation per file name, but OsString doesn't have any way to construct it way to construct it without that.

## Drop no longer needed newtype_array dependency

Doesn't seem to be needed any more. I don't believe this is part of the public API, so this is not a breaking change.

## Optimise type sizes based on which fields are actually present in Arch Linux mtrees

This optimises struct Params to be smaller. It is not part of the public API so this is not a breaking change.

In practise many of the types hashes are not seen on Arch Linux, and so we don't need to allocate memory for them. Similar goes for the uname/gname entries being larger than needed.